### PR TITLE
#104 both search results are not duplicated

### DIFF
--- a/blocks/search/search.js
+++ b/blocks/search/search.js
@@ -139,15 +139,16 @@ async function getAndApplyFiltersData(form) {
 
 function searchCRPartNumValue(value) {
   const partNumberBrands = ['OEM_num', 'Base Part Number', 'VOLVO_RC', 'MACK_1000'];
-  let results;
+  const results = new Set();
   partNumberBrands.forEach((brand) => {
-    if (results && results.length > 0) return;
     const tempResults = crData.filter(
-      (item) => new RegExp(value, 'i').test(item[brand]),
+      (item) => new RegExp(`.*${value}.*`, 'i').test(item[brand]),
     );
-    results = tempResults.length > 0 ? tempResults : null;
+    if (tempResults.length > 0) {
+      tempResults.forEach((item) => results.add(item));
+    }
   });
-  return results;
+  return [...results];
 }
 
 function filterResults(results, filter, isMake = true) {
@@ -157,23 +158,18 @@ function filterResults(results, filter, isMake = true) {
 
 function searchPartNumValue(value, make, model) {
   const partNumberBrands = ['Base Part Number', 'Volvo Part Number', 'Mack Part Number'];
-  let results = [];
+  const results = new Set();
   partNumberBrands.forEach((brand) => {
-    let tempResults = pnData.filter((item) => new RegExp(value, 'i').test(item[brand]));
+    let tempResults = pnData.filter((item) => new RegExp(`.*${value}.*`, 'i').test(item[brand]));
     if (make !== 'null' && tempResults.length > 0) {
       tempResults = filterResults(tempResults, make);
     }
     if (model !== 'null' && tempResults.length > 0) {
       tempResults = filterResults(tempResults, model, false);
     }
-    if (results.length > 0) {
-      const isEqualLength = results.length === tempResults.length;
-      results = (isEqualLength && [...results])
-        || results.filter((item, i) => item !== tempResults[i]);
-    }
-    results = tempResults.length > 0 ? results.concat(tempResults) : [...results];
+    tempResults.forEach((item) => results.add(item));
   });
-  return results;
+  return [...results];
 }
 
 function getFieldValue(selector, items) {


### PR DESCRIPTION
The search block has been improved to search the pattern at the beginning, in the middle, or at the end of the string.
Also, it avoids duplication using a Set, instead of an Array and it returns the values using a spread operator to return it as an array.

if you search 'BUMBA000000' as part number search, it returns 5 results
if you search 'crc' as a cross-reference search it returns 29 results because 2 of them match the 'c' in its part numbers

Fix #104 

Test URLs:
- Before: https://main--vg-roadchoice-com--hlxsites.hlx.page/
- After: https://104-duplicate-search-results--vg-roadchoice-com--hlxsites.hlx.page/
