### PR TITLE
#108 also check if has multiple Models

### DIFF
--- a/blocks/search/search.js
+++ b/blocks/search/search.js
@@ -153,7 +153,16 @@ function searchCRPartNumValue(value) {
 
 function filterResults(results, filter, isMake = true) {
   const itemFilter = isMake ? 'Make' : 'Model';
-  return results.filter((item) => item[itemFilter].toLowerCase() === filter.toLowerCase());
+  return results.filter((item) => {
+    const itemValue = item[itemFilter].toLowerCase();
+    const filterValue = filter.toLowerCase();
+    // if is Model, can have a list of models
+    if (!isMake && itemValue.includes(',')) {
+      const modelArray = itemValue.split(',').map((s) => s.trim());
+      return modelArray.includes(filterValue);
+    }
+    return itemValue === filterValue;
+  });
 }
 
 function searchPartNumValue(value, make, model) {


### PR DESCRIPTION
The Make Autocar is not the only case that has in a single row multiple values separated by comma, so, I updated the `filterResults()` function to check if a Model value is a multiple to check if the selected model is in the list

tested with:
- Make: _Autocar_ & Model: _WX_
- Make: _Freightliner_ & Model: _Columbia_

Fix #108

Test URLs:
- Before: https://main--vg-roadchoice-com--hlxsites.hlx.page/
- After: https://108-no-results-wx-model--vg-roadchoice-com--hlxsites.hlx.page/
