### PR TITLE
#146 add a iframe YT block with a flavour variation

### DIFF
--- a/blocks/embed/embed.css
+++ b/blocks/embed/embed.css
@@ -1,0 +1,29 @@
+:root {
+  --embed-video-width: 100%;
+  --embed-video-height: 56.25%;
+  --default-width: var(--embed-video-width);
+  --default-height: var(--embed-video-height);
+}
+
+.embed-video-container {
+  position: relative;
+  width: var(--default-width);
+  padding-bottom: var(--default-height);
+  height: 0;
+  margin-block-end: 3rem;
+}
+
+.embed-video-container iframe {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
+@media (min-width: 768px) {
+  .embed-video-container {
+    width: var(--embed-video-width);
+    padding-bottom: var(--embed-video-height);
+  }
+}

--- a/blocks/embed/embed.js
+++ b/blocks/embed/embed.js
@@ -1,0 +1,29 @@
+import { createIframe, isVideoLink } from '../../scripts/scripts.js';
+
+const ratioWidth = 16;
+const ratioHeight = 9;
+const defaultWidth = '100';
+
+export default function decorate(block) {
+  const link = block.querySelector(':scope a');
+  const videoContainer = block.querySelector(':scope > div');
+  const isYTLink = isVideoLink(link);
+  // if has Width class, use that to set the ratio
+  const configWidth = block.className.includes('width-')
+    ? block.className.split('width-')[1].split(' ')[0] : null;
+  videoContainer.className = 'embed-video-container';
+  videoContainer.textContent = '';
+  if (!isYTLink) {
+    // eslint-disable-next-line no-console
+    console.warn('%cEmbed block: Not an embedded YouTube link', 'color: cornflowerblue', { link });
+    return;
+  }
+
+  if (configWidth !== null && configWidth !== defaultWidth) {
+    const newRatioHeight = Math.round((ratioHeight / ratioWidth) * configWidth);
+    videoContainer.style.setProperty('--embed-video-width', `${configWidth}%`);
+    videoContainer.style.setProperty('--embed-video-height', `${newRatioHeight}%`);
+  }
+
+  createIframe(link, { parentEl: videoContainer, className: 'embed-video' });
+}

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -229,12 +229,6 @@ export function decorateLinks(block) {
   [...block.querySelectorAll('a')]
     .filter(({ href }) => !!href)
     .forEach((link) => {
-      /* eslint-disable no-use-before-define */
-      if (isVideoLink(link)) {
-        addVideoShowHandler(link);
-        return;
-      }
-
       // handling modal links
       if (link.getAttribute('href').startsWith('/#id-modal')) {
         link.addEventListener('click', (event) => {
@@ -252,8 +246,8 @@ export function decorateLinks(block) {
       }
 
       const url = new URL(link.href);
-      const external = !url.host.match('macktrucks.com') && !url.host.match('.hlx.(page|live)') && !url.host.match('localhost');
-      if (url.host.match('build.macktrucks.com') || url.pathname.endsWith('.pdf') || external) {
+      const external = !url.host.match('roadchoice.com') && !url.host.match('.hlx.(page|live)') && !url.host.match('localhost');
+      if (url.pathname.endsWith('.pdf') || external) {
         link.target = '_blank';
       }
     });
@@ -393,121 +387,13 @@ loadPage();
 // video helpers
 
 /**
- * Checks if the url is a low resolution video url
-  * @param {string} url the url to check
- * @returns {boolean} true if the url is a low resolution video url
- */
-export function isLowResolutionVideoUrl(url) {
-  return url.split('?')[0].endsWith('.mp4');
-}
-
-/**
- * Checks if the link is a high or low resolution video link, and it's not inside an embed block
+ * Checks if the link is an embedded video link from YouTube
  * @param {Element} link the link to check
- * @returns {boolean} true if the link is a video link
+ * @returns {boolean} true if the link is a YouTube video link
  */
 export function isVideoLink(link) {
   const linkString = link.getAttribute('href');
-  return (linkString.includes('youtube.com/embed/')
-    || isLowResolutionVideoUrl(linkString))
-    && link.closest('.block.embed') === null;
-}
-
-/**
- * Selects the video link to use based on the preferred type and the cookie settings
- * @param {NodeList} links the list of links to check
- * @param {string} preferredType the preferred type of video
- * @returns {Element} the link to use
- */
-export function selectVideoLink(links, preferredType) {
-  const linksList = [...links];
-  const shouldUseYouTubeLinks = document.cookie.split(';').some((cookie) => cookie.trim().startsWith('OptanonConsent=1')) && preferredType !== 'local';
-  const youTubeLink = linksList.find((link) => link.getAttribute('href').includes('youtube.com/embed/'));
-  const localMediaLink = linksList.find((link) => link.getAttribute('href').split('?')[0].endsWith('.mp4'));
-
-  if (shouldUseYouTubeLinks && youTubeLink) {
-    return youTubeLink;
-  }
-  return localMediaLink;
-}
-
-/**
- * Creates a banner that will be shown when the user clicks on a low resolution video link
- * @returns {Element} the banner HTML element
- */
-export function createLowResolutionBanner() {
-  const lowResolutionMessage = getTextLabel('Low resolution video message');
-  const changeCookieSettings = getTextLabel('Change cookie settings');
-
-  const banner = createElement('div', { classes: ['low-resolution-banner'] });
-  banner.innerHTML = `${lowResolutionMessage} <button class="low-resolution-banner-cookie-settings">${changeCookieSettings}</button>`;
-  banner.querySelector('button').addEventListener('click', () => {
-    window.OneTrust.ToggleInfoDisplay();
-  });
-
-  return banner;
-}
-
-/**
- * Shows the video modal
- * @param {string} linkUrl the url of the video to show in the modal based on the cookie settings
- */
-export function showVideoModal(linkUrl) {
-  // eslint-disable-next-line import/no-cycle
-
-  // Added a false gate until modal is created
-  // const route = '../common/modal/modal-component.js'
-  const route = false;
-  if (route) {
-    import(route).then((modal) => {
-      let beforeBanner = null;
-
-      if (isLowResolutionVideoUrl(linkUrl)) {
-        beforeBanner = createLowResolutionBanner();
-      }
-
-      modal.showModal(linkUrl, { beforeBanner });
-    });
-  }
-}
-
-/**
- * Adds the video click handler to the link to show the video modal
- * @param {Element} link the link to add the handler to
-*/
-export function addVideoShowHandler(link) {
-  link.classList.add('text-link-with-video');
-
-  link.addEventListener('click', (event) => {
-    event.preventDefault();
-
-    showVideoModal(link.getAttribute('href'));
-  });
-}
-
-/**
- * Adds the play icon to the link
- * @param {Element} parent the link to add the icon to as a child
-*/
-export function addPlayIcon(parent) {
-  const iconWrapper = createElement('div', { classes: ['video-icon-wrapper'] });
-  const icon = createElement('i', { classes: ['fa', 'fa-play', 'video-icon'] });
-  iconWrapper.appendChild(icon);
-  parent.appendChild(iconWrapper);
-}
-
-/**
- * Wraps the image with the link and adds the play icon
- * @param {Element} videoLink the link to wrap the image with
- * @param {Element} image the image to wrap
-*/
-export function wrapImageWithVideoLink(videoLink, image) {
-  videoLink.innerText = '';
-  videoLink.appendChild(image);
-  videoLink.classList.add('link-with-video');
-  videoLink.classList.remove('button', 'primary', 'text-link-with-video');
-
-  addPlayIcon(videoLink);
+  return (linkString.includes('youtube.com/embed/'));
 }
 
 /**


### PR DESCRIPTION
Add an iframe element using the url and also has a flavour variation based on the width
I have some examples of how it looks
1st is a 100% block, then 75% and 50%
in the block configuration grabs the width class width the follow structure:
(width-[amount]), e.g.: embed (width-75)
see my draft as an example
drafts/jlledo/embed-demo

test path:
about/

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--vg-roadchoice-com--hlxsites.hlx.page/
- After: https://146-embed-block--vg-roadchoice-com--hlxsites.hlx.page/
