### PR TITLE
#134 fix pdp styling, image load & category filter

### DIFF
--- a/blocks/dealer-locator/dealer-locator.css
+++ b/blocks/dealer-locator/dealer-locator.css
@@ -7,6 +7,7 @@
   height: 100vh;
   position: absolute;
   left: 0;
+  z-index: 0;
 }
 
 main .section.dealer-locator-container > div {

--- a/blocks/pdp/pdp.css
+++ b/blocks/pdp/pdp.css
@@ -4,20 +4,18 @@
 }
 
 .pdp {
-  padding: 15px;
+  padding: 15px 0;
   min-height: 650px;
 }
 
 .pdp-title {
  color: var(--primary-red);
- font-size: 50px;
  font-weight: 500;
 }
 
 .pdp-details-wrapper {
   display: flex;
   flex-direction: column;
-  padding: 0 30px;
 }
 
 .pdp-list-item {
@@ -39,7 +37,6 @@
 .pdp-selected-image {
   padding: 5px;
   border-radius: 4px;
-  aspect-ratio: 1;
   box-shadow: 0 1px 4px 0 rgba(0 0 0 / 10%);
   display: flex;
   justify-content: center;
@@ -162,8 +159,8 @@
   border: 5px solid var(--c-yellow);
 }
 
-.section.accordion.pdp-part-fit h5{
-  font-size: 15px;
+.section.accordion.pdp-part-fit h5 {
+  font-size: 12px;
   font-family: var(--body-ff);
   background-color: var(--c-yellow);
   color: var(--primary-black);
@@ -171,6 +168,11 @@
   display: flex;
   height: 57px;
   align-items: baseline;
+}
+
+.section.accordion.pdp-part-fit h5::before,
+.section.accordion.pdp-part-fit h5::after {
+  font-size: 15px;
 }
 
 .section.accordion.accordion-open h5::before {
@@ -232,7 +234,7 @@
 
 .pdp-part-fit-search-input {
   height: 56px;
-  width: 400px;
+  width: 100%;
   font-size: 16px;
   padding: 17px 17px 17px 56px;
   border-radius: 28px;
@@ -280,9 +282,8 @@
 }
 
 .pdp-part-fit-list {
-  display: grid;
-  grid-auto-rows: 200px;
-  grid-template-columns: 1fr;
+  display: flex;
+  flex-direction: column;
   gap: 50px 4%;
 }
 
@@ -301,25 +302,23 @@
 }
 
 .pdp-part-fit-make {
-  font-size: 32px;
   font-family: var(--headings-ff-black);
   text-transform: none;
   margin: 0;
 }
 
 .pdp-part-fit-model {
-  font-size: 24px;
   font-family: var(--headings-ff-black);
   color: var(--primary-red);
   text-transform: none;
-  margin: 0;
+  margin: 0 0 25px;
 }
 
 .pdp-part-fit-model-description,
 .pdp-part-fit-year,
 .pdp-part-fit-engine-make,
 .pdp-part-fit-engine-model {
-  font-size: 16px;
+  font-size: var(--body-font-size-xs);
   line-height: 1.2;
   margin: 0;
 }
@@ -366,10 +365,44 @@
 }
 
 .section.breadcrumbs + .section.pdp-container {
-  padding-top: 0;
+  padding: 0 32px;
 }
 
-@media screen and (min-width: 767px) {
+@media (min-width: 400px) {
+  .section.accordion.pdp-part-fit h5 {
+    font-size: 15px;
+  }
+
+  .pdp-part-fit-list {
+    display: grid;
+    grid-auto-rows: 200px;
+    grid-template-columns: 1fr;
+  }
+
+  .pdp-part-fit-make {
+    font-size: 32px;
+  }
+
+  .pdp-part-fit-model {
+    font-size: 24px;
+    margin: 0;
+  }
+
+  .pdp-part-fit-model-description,
+  .pdp-part-fit-year,
+  .pdp-part-fit-engine-make,
+  .pdp-part-fit-engine-model {
+    font-size: 16px;
+  }
+}
+
+@media (min-width: 595px) {
+  .pdp-part-fit-list {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+@media (min-width: 767px) {
   .pdp-details-wrapper {
     flex-direction: row-reverse;
     padding: 0;
@@ -392,10 +425,6 @@
 
   .pdp-selected-image {
     display: block;
-  }
-
-  .section.accordion {
-    padding: 20px 16px;
   }
 
   .pdp-part-fit-expanded {
@@ -434,7 +463,7 @@
   }
 }
 
-@media screen and (min-width: 1025px) {
+@media (min-width: 1025px) {
   .pdp-image-wrapper {
     max-width: calc(100% - 150px);
     margin: auto;

--- a/blocks/pdp/pdp.js
+++ b/blocks/pdp/pdp.js
@@ -1,4 +1,10 @@
-import { createElement, getTextLabel, getJsonFromUrl } from '../../scripts/scripts.js';
+import {
+  createElement,
+  getTextLabel,
+  getJsonFromUrl,
+  getLongJSONData,
+  defaultLimit,
+} from '../../scripts/scripts.js';
 import { createOptimizedPicture } from '../../scripts/lib-franklin.js';
 
 const docRange = document.createRange();
@@ -20,7 +26,7 @@ async function getPDPData(pathSegments) {
   const { category, sku } = pathSegments;
 
   try {
-    const { data } = await getJsonFromUrl(`/product-data/rc-${category.replace(/[^\w]/g, '-')}.json`);
+    const { data } = await getJsonFromUrl(`/product-data/rc-${category.replaceAll(' ', '-')}.json`);
     return findPartBySKU(data, sku);
   } catch (error) {
     // eslint-disable-next-line no-console
@@ -36,7 +42,10 @@ function findPartImagesBySKU(parts, sku) {
 async function fetchPartImages(sku) {
   const placeholderImage = '/product-images/rc-placeholder-image.png';
   try {
-    const { data } = await getJsonFromUrl('/product-images/road-choice-website-images.json');
+    const data = await getLongJSONData({
+      url: '/product-images/road-choice-website-images.json',
+      limit: defaultLimit,
+    });
     const images = findPartImagesBySKU(data, sku);
 
     if (images.length !== 0) {

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -709,6 +709,8 @@ export function checkLinkProps(links) {
 const allLinks = [...document.querySelectorAll('a'), ...document.querySelectorAll('button')];
 checkLinkProps(allLinks);
 
+// fetch data helpers
+
 /**
  * Returns a list of properties listed in the block
  * @param {string} route get the Json data from the route
@@ -725,6 +727,87 @@ export const getJsonFromUrl = async (route) => {
     console.error('getJsonFromUrl:', { error });
   }
   return null;
+};
+
+/**
+ * Save the fetched data in a temporary array
+*/
+const tempData = [];
+/**
+ * The default limit of the fetched data
+ */
+export const defaultLimit = 100_000;
+
+/**
+ * Returns a list of properties listed in the block
+ * @param {Object} props the block props
+ * @param {string} props.url get the Json data from the route
+ * @param {number} props.offset the offset of the data
+ * @param {number} props.limit the limit of the data
+ * @returns {Object} the json data object
+*/
+const getInitialJSONData = async (props) => {
+  try {
+    const { url, offset = 0, limit = null } = props;
+    const nextOffset = offset > 0 ? `?offset=${offset}` : '';
+    const nextLimit = limit ? `${offset > 0 ? '&' : '?'}limit=${limit}` : '';
+    const results = await fetch(`${url}${nextOffset}${nextLimit}`);
+    const json = await results.json();
+    return json;
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('getInitialJSONData:', { error });
+    return null;
+  }
+};
+
+/**
+ * Returns a more data if the limit is reached
+ * @param {string} url get the Json data from the route
+ * @param {number} total the total of the data
+ * @param {number} offset the offset of the data
+ * @param {number} limit the limit of the data
+ * @returns {Object} the json data object
+ * @example getMoreJSONData('https://roadchoice.com/api/news', 1000, 0, 100_000)
+*/
+async function getMoreJSONData(url, total, offset = 0, limit = defaultLimit) {
+  try {
+    const newOffset = offset + limit;
+    const json = await getInitialJSONData({ url, offset: newOffset, limit });
+    const isLastCall = json.offset + limit >= json.total;
+    if (isLastCall) {
+      const lastData = [...tempData, ...json.data];
+      tempData.length = 0;
+      return lastData;
+    }
+    tempData.push(...json.data);
+    return getMoreJSONData(total, newOffset);
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('getMoreJSONData:', { error });
+    return null;
+  }
+}
+
+/**
+ * Return the data from the url if it has more than the default limit
+ * @param {Object} props the block props
+ * @param {string} props.url get the Json data from the route
+ * @param {number} props.offset the offset of the data
+ * @param {number} props.limit the limit of the data
+ * @returns {Object} the json data object
+ * @example getLongJSONData({ url:'https://roadchoice.com/api/news', limit: 100_000, offset: 1000})
+ */
+export const getLongJSONData = async (props) => {
+  const { url } = props;
+  const json = await getInitialJSONData(props);
+  if (!json) return null;
+  const initialData = [...json.data];
+  let moreData;
+  if (json.total > json.limit) {
+    moreData = await getMoreJSONData(url, json.total);
+  }
+  return moreData ? [...initialData, ...moreData] : initialData;
 };
 
 /**

--- a/templates/part-category/part-category.js
+++ b/templates/part-category/part-category.js
@@ -55,7 +55,7 @@ const getFilterAttrib = async (cat) => {
     const json = await getJsonFromUrl(categoryMaster);
     if (!json) throw new Error('No data found in category master file');
     const filterAttribs = json.data.filter((el) => (
-      el.Subcategory.toLowerCase() === cat.toLowerCase()
+      el.Subcategory.toLowerCase() === cat.toLowerCase().replaceAll('-', ' ')
       && el.Filter === ''
     )).map((el) => el.Attributes);
     const event = new Event('FilterAttribsLoaded');


### PR DESCRIPTION
Fixes:
- category filter does load the filter properties if the category has multiple words
- add an extended fetching function to load all the lines in the file, not only the 1000 first ones
- fix mobile styling
- The dealer locator page, now shows the whole category dropdown and is not blocked by the side tool


Fix #134 

Test URLs:
- Before: https://main--vg-roadchoice-com--hlxsites.hlx.page/
- After: https://134-mobile-styleing-issues--vg-roadchoice-com--hlxsites.hlx.page/
