### PR TITLE
#161 nav PDFs open in a new tab

### DIFF
--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -187,6 +187,8 @@ export default async function decorate(block) {
       const sectionClasses = ['main', 'mobile'];
       const sectionNavs = navSections.querySelectorAll(':scope > ul');
       if (sectionNavs.length === sectionClasses.length) {
+        const sectionPDFs = navSections.querySelectorAll('a[href$=".pdf"]');
+        [...sectionPDFs].forEach((pdf) => { pdf.target = '_blank'; });
         sectionNavs[0].className = 'level-1';
         sectionClasses.forEach((c, i) => sectionNavs[i].classList.add(`nav-sections-${c}`));
       }


### PR DESCRIPTION
header block now searches for PDF links and then adds a `target:="_blank"` attribute to be opened in another tab

Fix #161 

Test URLs:
- Before: https://main--vg-roadchoice-com--hlxsites.hlx.page/
- After: https://161-menu-pdf-link-open-a-new-tab--vg-roadchoice-com--hlxsites.hlx.page/
