### PR TITLE
160 re create breadcrumb

### DIFF
--- a/blocks/breadcrumb/breadcrumb.js
+++ b/blocks/breadcrumb/breadcrumb.js
@@ -1,24 +1,20 @@
-import {
-  getMetadata,
-} from '../../scripts/lib-franklin.js';
+import { getMetadata } from '../../scripts/lib-franklin.js';
 import { createElement, getTextLabel } from '../../scripts/scripts.js';
 
 const homeText = getTextLabel('brand name');
-const homeUrl = getTextLabel('home url');
+const url = new URL(window.location.href);
 
 const pageName = getMetadata('og:title');
 
 export default async function decorate(block) {
   const breadcrumbContent = createElement('div', { classes: ['breadcrumb-content'] });
   const breadcrumbList = createElement('ul', { classes: ['breadcrumb-list'] });
-  const currentUrl = window.location.pathname;
+  const currentUrl = url.pathname;
 
   const routes = currentUrl.split('/');
   if (routes[0].length === 0) routes[0] = '/';
 
   const amountOfLevels = routes.length - 1;
-  let partialUrl = homeUrl;
-
   const isBlogArticle = document.querySelector('.blog-article');
 
   routes.forEach((path, idx) => {
@@ -26,11 +22,11 @@ export default async function decorate(block) {
     const item = createElement('li', { classes: ['breadcrumb-item', `breadcrumb-item-${idx}`] });
     const link = createElement('a', { classes: ['breadcrumb-link'] });
 
-    partialUrl = idx === 0 ? homeUrl : `${partialUrl}${path}/`;
-    link.href = partialUrl;
+    link.href = idx === 0 ? url.origin : `${url.origin}/${path}/`;
 
     if (idx === amountOfLevels && isBlogArticle) {
-      link.innerHTML = pageName.toLowerCase();
+      link.href = `${url.origin}/blog/${path}`;
+      link.innerHTML = `${pageName.toLowerCase()} /`;
       link.classList.add('active-link');
     } else {
       link.innerHTML = idx === 0 ? homeText : path;

--- a/placeholder.json
+++ b/placeholder.json
@@ -1,15 +1,11 @@
 {
-  "total": 21,
+  "total": 20,
   "offset": 0,
-  "limit": 21,
+  "limit": 20,
   "data": [
     {
       "Key": "brand name",
       "Text": "Road Choice"
-    },
-    {
-      "Key": "home url",
-      "Text": "https://main--vg-roadchoice-com--hlxsites.hlx.page/"
     },
     {
       "Key": "recommendations title",

--- a/templates/part-category/part-category.js
+++ b/templates/part-category/part-category.js
@@ -5,6 +5,7 @@ const amount = 12;
 const url = new URL(window.location.href);
 const urlParams = new URLSearchParams(url.search);
 let category;
+let mainCategory;
 
 /* Cases that throw an error if the category is wrong or missing that goes to 404 page:
  * 1. "/part-category/" => 404 if is index path
@@ -33,6 +34,7 @@ const getCategoryData = async (cat) => {
     const json = await getJsonFromUrl(url);
     if (!json) throw new Error(`No data found in "${cat}" category file`);
     const event = new Event('CategoryDataLoaded');
+    mainCategory = json.data[0].Category;
     sessionStorage.setItem('category-data', (json ? JSON.stringify(json.data) : null));
     sessionStorage.setItem('amount', amount);
     document.dispatchEvent(event);
@@ -91,7 +93,7 @@ export default async function decorate(doc) {
   titleWrapper.appendChild(title);
   section.prepend(titleWrapper);
   resetCategoryData();
-  getCategoryData(category);
+  await getCategoryData(category);
   getFilterAttrib(category);
 
   // update breadcrumb adding the category dynamically
@@ -110,6 +112,14 @@ export default async function decorate(doc) {
       const breadcrumbItem = createElement('li', {
         classes: ['breadcrumb-item', `breadcrumb-item-${length}`],
       });
+
+      if (!mainCategory) {
+        lastElLink.href = new URL(window.location.href).origin;
+      } else {
+        lastElLink.href += mainCategory.replace(/\s/g, '-');
+        lastElLink.textContent = mainCategory.toLowerCase();
+      }
+
       breadcrumbItem.appendChild(link);
       breadcrumbList.appendChild(breadcrumbItem);
       observer.disconnect();

--- a/templates/part-category/part-category.js
+++ b/templates/part-category/part-category.js
@@ -116,8 +116,9 @@ export default async function decorate(doc) {
       if (!mainCategory) {
         lastElLink.href = new URL(window.location.href).origin;
       } else {
+        mainCategory = mainCategory.toLowerCase();
         lastElLink.href += mainCategory.replace(/\s/g, '-');
-        lastElLink.textContent = mainCategory.toLowerCase();
+        lastElLink.textContent = mainCategory;
       }
 
       breadcrumbItem.appendChild(link);


### PR DESCRIPTION
Fix an issue in subcategory pages where the breadcrumb links point to a 404 page in the part-category link.
Now the link is transformed into a blog category link.

Also, I refactored the breadcrumb block to use the `URL` Object, grabbing the current URL, and removing the need to get data from the placeholder.json

Fix #160 

Test URLs:
- Before: https://main--vg-roadchoice-com--hlxsites.hlx.page/
- After: https://160-re-create-breadcrumb--vg-roadchoice-com--hlxsites.hlx.page/
