### PR TITLE
#160 fix breadcrumb in pdp page

### DIFF
--- a/blocks/pdp/pdp.js
+++ b/blocks/pdp/pdp.js
@@ -485,7 +485,7 @@ function renderBreadcrumbs(part) {
             </li>
             <li class="breadcrumb-item breadcrumb-item-2">
               <a class="breadcrumb-link"
-                href="/part-category/${part.Subcategory.toLowerCase().replace(/[^\w]/g, '-')}">
+                href="/part-category/?category=${part.Subcategory.toLowerCase().replace(/[^\w]/g, '-')}">
                 ${part.Subcategory}
               </a>
             </li>


### PR DESCRIPTION
in a PDP page, the subcategory link in Breadcrumb now goes to its subcategory page

test path:
parts?category=bumpers&sku=BUMBA000000

Fix #160 

Test URLs:
- Before: https://main--vg-roadchoice-com--hlxsites.hlx.page/
- After: https://160-fix-pdp-breadcrumb-category--vg-roadchoice-com--hlxsites.hlx.page/
