### PR TITLE
#169 accordion title resize in view-ports

### DIFF
--- a/blocks/breadcrumb/breadcrumb.js
+++ b/blocks/breadcrumb/breadcrumb.js
@@ -17,12 +17,14 @@ export default async function decorate(block) {
   const amountOfLevels = routes.length - 1;
   const isBlogArticle = document.querySelector('.blog-article');
 
+  let tempUrl = '';
   routes.forEach((path, idx) => {
     if (path.length === 0) return;
     const item = createElement('li', { classes: ['breadcrumb-item', `breadcrumb-item-${idx}`] });
     const link = createElement('a', { classes: ['breadcrumb-link'] });
+    tempUrl += idx === 0 ? path : `${path}/`;
 
-    link.href = idx === 0 ? url.origin : `${url.origin}/${path}/`;
+    link.href = idx === 0 ? url.origin : `${url.origin}${tempUrl}`;
 
     if (idx === amountOfLevels && isBlogArticle) {
       link.href = `${url.origin}/blog/${path}`;

--- a/blocks/pdp/pdp.css
+++ b/blocks/pdp/pdp.css
@@ -136,6 +136,12 @@
   padding: 5px 0;
   margin: 0 0 15px;
   cursor: pointer;
+  font-size: 70%;
+  transition: font-size 0.3s ease-in-out;
+}
+
+.section.accordion.accordion-open h5 {
+  font-size: var(--heading-font-size-s);
 }
 
 .section.accordion.accordion-open,
@@ -369,6 +375,10 @@
 }
 
 @media (min-width: 400px) {
+  .section.accordion h5 {
+    font-size: 90%;
+  }
+
   .section.accordion.pdp-part-fit h5 {
     font-size: 15px;
   }
@@ -399,6 +409,10 @@
 @media (min-width: 595px) {
   .pdp-part-fit-list {
     grid-template-columns: 1fr 1fr;
+  }
+
+  .section.accordion h5 {
+    font-size: var(--heading-font-size-s);
   }
 }
 


### PR DESCRIPTION
I added a transition and a different title size to fit in mobile & + viewports to fit in the view
also, fix an issue related to breadcrumbs in long paths like the following one:
resources/safety-data-sheets-sds/paint

the problem was that each item link didn't accumulate the previous path level. now is fixed

Fix #169

Test URLs:
- Before: https://main--vg-roadchoice-com--hlxsites.hlx.page/
- After: https://169-title-accordion-visibility--vg-roadchoice-com--hlxsites.hlx.page/
