### PR TITLE
69 find a dealer style issues

### DIFF
--- a/404.html
+++ b/404.html
@@ -45,6 +45,7 @@
     .error h1 {
       color: var(--primary-red);
       font-size: 50px;
+      line-height: normal;
     }
 
     .error .default ul {

--- a/blocks/carousel/carousel.css
+++ b/blocks/carousel/carousel.css
@@ -61,6 +61,7 @@ main .section.carousel-container {
 .carousel .carousel-slide a.button {
   background-color: inherit;
   padding: 0;
+  width: 800px;
 }
 
 .carousel .carousel-slide-background {
@@ -85,6 +86,7 @@ main .section.carousel-container {
   flex-direction: column;
   gap: 20px;
   line-height: 1;
+  align-items: center;
 }
 
 .carousel .carousel-controls {

--- a/blocks/find-dealer/find-dealer.css
+++ b/blocks/find-dealer/find-dealer.css
@@ -1,11 +1,9 @@
-.find-dealer-container {
-  background-size: cover;
-  background-color: var(--primary-black);
-}
-
 .section.find-dealer-container {
   max-width: unset;
   padding: 10px 16px;
+  background-size: cover;
+  background-color: var(--primary-black);
+  background-position-x: 50%;
 }
 
 .find-dealer-wrapper {
@@ -25,7 +23,7 @@
   align-items: center;
   color: var(--primary-white);
   text-align: center;
-  padding: 5rem;
+  padding: 5rem 1rem;
   gap: 3rem;
   font-family: var(--body-ff);
   width: 90%;
@@ -42,6 +40,7 @@
 
 .find-dealer-form-container .find-dealer-col-1 .find-dealer-text {
   color: var(--primary-white);
+  margin: 0 -2.5rem;
 }
 
 .find-dealer-form-container .find-dealer-col-2 {
@@ -84,14 +83,21 @@
   }
 }
 
+@media (min-width: 375px) {
+  .find-dealer-form-container .find-dealer-col-1 .find-dealer-text {
+    margin: 0;
+  }
+}
+
 @media (min-width: 768px) {
   .find-dealer-form-container {
     flex-direction: initial;
     padding: 7rem 0;
+    gap: 6rem;
   }
 
   .find-dealer-form-container .find-dealer-col-1 {
-    font-size: inherit;
+    font-size: 22px;
     width: 55%;
     text-align: initial;
   }
@@ -120,5 +126,9 @@
 
   .find-dealer-form-container .find-dealer-col-1 {
     width: 50%;
+  }
+
+  .find-dealer-form-container .find-dealer-col-1 .find-dealer-text {
+    font-size: var(--body-font-size-m);
   }
 }

--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -427,11 +427,11 @@ header .nav-tools .categories a {
   }
 
   header .nav-tools .categories[aria-expanded="true"] .level-2 {
-    padding: 6rem 6rem 11rem;
+    padding: 6rem 6rem 20rem;
     display: flex;
     flex-flow: column wrap;
     gap: 8rem 3rem;
-    height: 1650px;
+    height: 1450px;
     font-size: var(--nav-font-size);
   }
 


### PR DESCRIPTION
Minor fixes: 
- categories dropdown items realign to fit better in their columns
- fix the 404 h1 title line height to not overlap in the mobile viewport
- 1st slide in the carousel is too long at 1200px width, so I expanded the size of the text to be a bit wider and now not overlap it with the dots

Fix #48 
now the font is 17px and 22px the space between the 2 columns is different

Fix #69 
_The text is shown on 4lines instead on 3lines as expected_ ✅done
_The 'WHERE TO BUY' has more line spacing than expected_ ✅done
_The background image is not focused correctly thus, it looks like a different image_ ✅done
_The magnifier glass has thick border than expected_ ❌Not done because is using font awesome 4 instead of an SVG image

Test URLs:
- Before: https://main--vg-roadchoice-com--hlxsites.hlx.page/
- After: https://69-find-a-dealer-style-issues--vg-roadchoice-com--hlxsites.hlx.page/
