### PR TITLE
181 cr description search

### DIFF
--- a/blocks/carousel/carousel.css
+++ b/blocks/carousel/carousel.css
@@ -61,7 +61,6 @@ main .section.carousel-container {
 .carousel .carousel-slide a.button {
   background-color: inherit;
   padding: 0;
-  width: 800px;
 }
 
 .carousel .carousel-slide-background {
@@ -186,5 +185,9 @@ main .section.carousel-container {
   .carousel .carousel-slide,
   .carousel .carousel-slide a {
     font-size: 52px;
+  }
+
+  .carousel .carousel-slide a.button {
+    width: 800px;
   }
 }

--- a/blocks/filters/filters.js
+++ b/blocks/filters/filters.js
@@ -4,6 +4,7 @@ let products;
 const titleContent = getTextLabel('Categories');
 const isSearchResult = document.querySelector('.search-results') !== null;
 const urlCategory = new URLSearchParams(window.location.search).get('cat');
+const total = +sessionStorage.getItem('total-results-amount') || 0;
 
 if (isSearchResult) products = JSON.parse(sessionStorage.getItem('results')) || [];
 
@@ -48,7 +49,7 @@ const buildFilter = (cats) => {
     const link = createElement('a', {
       classes: 'categories-link',
       props: { href: filterUrl },
-      textContent: `${category.toLowerCase()} (${amount})`,
+      textContent: `${category.toLowerCase()} (${total >= amount ? total : amount})`,
     });
     item.appendChild(link);
     list.appendChild(item);
@@ -74,9 +75,6 @@ const decorateFilter = (block) => {
 export default async function decorate(block) {
   document.addEventListener('DataLoaded', ({ detail }) => {
     products = detail.results;
-    if (!sessionStorage.getItem('results')) {
-      sessionStorage.setItem('results', JSON.stringify(products));
-    }
     if (products.length > 0) decorateFilter(block);
   });
 

--- a/blocks/pagination/pagination.js
+++ b/blocks/pagination/pagination.js
@@ -88,9 +88,6 @@ export default async function decorate(block) {
   document.addEventListener('DataLoaded', ({ detail }) => {
     products = detail.results;
     imageData = detail.data.imgData;
-    if (!sessionStorage.getItem('results')) {
-      sessionStorage.setItem('results', JSON.stringify(products));
-    }
     if (!isDecorated) {
       isDecorated = true;
       if (products.length > 0) decoratePagination(block);

--- a/blocks/results-list/results-list.js
+++ b/blocks/results-list/results-list.js
@@ -1,13 +1,12 @@
 import { createElement } from '../../scripts/scripts.js';
 import productCard from './product-card.js';
 import { amountOfProducts } from '../search/search.js';
-import { results } from '../../templates/search-results/search-results.js';
+import { results, allProducts } from '../../templates/search-results/search-results.js';
 
 let amount = amountOfProducts;
 let products;
 let query;
 let category;
-let isRendered = false;
 const isSearchResult = document.querySelector('.search-results') !== null;
 
 if (isSearchResult) {
@@ -22,6 +21,7 @@ if (isSearchResult) {
 
 const searchType = (query.searchType === 'cross' && 'cross') || 'parts';
 
+// eslint-disable-next-line object-curly-newline
 const renderResults = ({ loadingElement, productList, isTruckLibrary, detail }) => {
   loadingElement.remove();
   products = detail?.results;
@@ -49,37 +49,34 @@ export default async function decorate(block) {
 
   const isTruckLibrary = (text) => text.includes('trucklibrary.com');
 
-  console.log('%cresults-list no-listener', 'color: deeppink', { results, products, window, allProducts: window?.allProducts });
+  console.log('%cresults-list no-listener', 'color: deeppink', { results, products, allProducts, window_allProducts: window?.allProducts, window });
   if (results.length > 0) {
-    const images = window?.allProducts.imgData;
+    const imgData = window?.allProducts?.imgData || allProducts?.imgData || [];
     renderResults({
-      loadingElement, productList, isTruckLibrary, detail: { results, data: { imgData: images } },
+      loadingElement, productList, isTruckLibrary, detail: { results, data: { imgData } },
     });
-    isRendered = true;
+    if (!allProducts?.imgData) {
+      setTimeout(() => {
+        if (allProducts.imgData) {
+          const images = window?.allProducts?.imgData || allProducts?.imgData || [];
+          console.log({images});
+          productList.innerHTML = '';
+          renderResults({
+            loadingElement,
+            productList,
+            isTruckLibrary,
+            detail: { results, data: { imgData: images } },
+          });
+        }
+      }, 5000);
+    }
   }
 
   document.addEventListener('DataLoaded', ({ detail }) => {
-    console.log('%cDataLoaded results-list', 'color: deeppink', { isRendered });
-    if (isRendered) return;
+    console.log('%cDataLoaded results-list', 'color: deeppink');
     renderResults({
       loadingElement, productList, isTruckLibrary, detail,
     });
-    // loadingElement.remove();
-    // products = detail?.results;
-    // if (products.length === 0) return;
-    // products.forEach((prod, idx) => {
-    //   prod.hasImage = false;
-    //   const filterLoop = detail.data.imgData.filter((e) => e['Part Number'] === prod['Base Part Number']
-    //   && ((isTruckLibrary(e['Image URL']) && e['Image URL'].includes('.0?$'))
-    //   || (!isTruckLibrary(e['Image URL']) && e['Image URL'].includes('-0.jpg'))));
-    //   if (filterLoop.length >= 1) {
-    //     prod.hasImage = true;
-    //     prod.imgUrl = filterLoop[0]['Image URL'];
-    //   }
-    //   const productItem = productCard(prod, searchType);
-    //   if (idx >= amount) productItem.classList.add('hidden');
-    //   productList.appendChild(productItem);
-    // });
   });
 
   resultsSection.append(productList);

--- a/blocks/results-list/results-list.js
+++ b/blocks/results-list/results-list.js
@@ -1,6 +1,7 @@
 import { createElement } from '../../scripts/scripts.js';
 import productCard from './product-card.js';
 import { amountOfProducts } from '../search/search.js';
+import { results } from '../../templates/search-results/search-results.js';
 
 let amount = amountOfProducts;
 let products;
@@ -28,6 +29,7 @@ export default async function decorate(block) {
 
   const isTruckLibrary = (text) => text.includes('trucklibrary.com');
 
+  console.log('%cresults-list no-listener', 'color: deeppink', { results, products, query, category, searchType, window });
   document.addEventListener('DataLoaded', ({ detail }) => {
     console.log('%cDataLoaded results-list', 'color: deeppink');
     loadingElement.remove();

--- a/blocks/results-list/results-list.js
+++ b/blocks/results-list/results-list.js
@@ -49,8 +49,8 @@ export default async function decorate(block) {
 
   const isTruckLibrary = (text) => text.includes('trucklibrary.com');
 
-  console.log('%cresults-list no-listener', 'color: deeppink', { results, products, query, category, searchType, window });
-  if (!isRendered && results.length > 0) {
+  console.log('%cresults-list no-listener', 'color: deeppink', { results, products, window, allProducts: window?.allProducts });
+  if (results.length > 0) {
     const images = window?.allProducts.imgData;
     renderResults({
       loadingElement, productList, isTruckLibrary, detail: { results, data: { imgData: images } },

--- a/blocks/results-list/results-list.js
+++ b/blocks/results-list/results-list.js
@@ -29,6 +29,7 @@ export default async function decorate(block) {
   const isTruckLibrary = (text) => text.includes('trucklibrary.com');
 
   document.addEventListener('DataLoaded', ({ detail }) => {
+    console.log('%cDataLoaded results-list', 'color: deeppink');
     loadingElement.remove();
     products = detail?.results;
     if (products.length === 0) return;

--- a/blocks/results-list/results-list.js
+++ b/blocks/results-list/results-list.js
@@ -49,7 +49,6 @@ export default async function decorate(block) {
 
   const isTruckLibrary = (text) => text.includes('trucklibrary.com');
 
-  console.log('%cresults-list no-listener', 'color: deeppink', { results, products, allProducts, window_allProducts: window?.allProducts, window });
   if (results.length > 0) {
     const imgData = window?.allProducts?.imgData || allProducts?.imgData || [];
     renderResults({
@@ -59,7 +58,6 @@ export default async function decorate(block) {
       setTimeout(() => {
         if (allProducts.imgData) {
           const images = window?.allProducts?.imgData || allProducts?.imgData || [];
-          console.log({images});
           productList.innerHTML = '';
           renderResults({
             loadingElement,
@@ -73,7 +71,6 @@ export default async function decorate(block) {
   }
 
   document.addEventListener('DataLoaded', ({ detail }) => {
-    console.log('%cDataLoaded results-list', 'color: deeppink');
     renderResults({
       loadingElement, productList, isTruckLibrary, detail,
     });

--- a/blocks/search/search.js
+++ b/blocks/search/search.js
@@ -146,6 +146,7 @@ async function getAndApplyFiltersData(form) {
 export function searchCRPartNumValue(value, data = crData) {
   const partNumberBrands = ['OEM_num', 'Base Part Number', 'VOLVO_RC', 'MACK_1000'];
   const results = new Set();
+  if (value === ''.trim()) return [];
   partNumberBrands.forEach((brand) => {
     const tempResults = data.filter(
       (item) => new RegExp(`.*${value}.*`, 'i').test(item[brand]),
@@ -192,6 +193,7 @@ export function searchPartNumValue(value, make, model, data = pnData) {
   // search by part number
   const partNumberBrands = ['Base Part Number', 'Volvo Part Number', 'Mack Part Number'];
   const results = new Set();
+  if (value === ''.trim() && make === 'null' && model === 'null') return [];
   partNumberBrands.forEach((brand) => {
     filterPNByColumn({ column: brand, data, value, make, model, results });
   });

--- a/blocks/search/search.js
+++ b/blocks/search/search.js
@@ -1,3 +1,4 @@
+/* eslint-disable object-curly-newline */
 import { createElement, getJsonFromUrl as getFiltersData, getTextLabel } from '../../scripts/scripts.js';
 
 let isCrossRefActive = true;
@@ -7,10 +8,13 @@ const FILTERS_DATA = '/search/search-filters.json';
 let crData;
 let pnData;
 export const amountOfProducts = 12;
+let fitInStorage = true;
+export const fitAmount = 5000;
 
 const PLACEHOLDERS = {
   crossReference: getTextLabel('Cross-Reference No'),
   partNumber: getTextLabel('Part No'),
+  partNumberLabel: getTextLabel('Part Number Label'),
 };
 
 const TEMPLATES = {
@@ -60,7 +64,7 @@ const TEMPLATES = {
   `,
   inputPN: `
   <div class="search__input-pn__container">
-    <label class="search__input-pn__label">Part Number</label>
+    <label class="search__input-pn__label">${PLACEHOLDERS.partNumberLabel}</label>
     <div class="search__input-pn__wrapper">
       <input class="search__input-pn__input shadow" type="search" placeholder="${PLACEHOLDERS.partNumber}" />
       <button class="button search__input-pn__submit shadow search-button" type="submit">
@@ -171,21 +175,30 @@ function filterByOthersMake(results) {
   return results.filter((item) => !noOthersItems.includes(item.Make));
 }
 
+function filterPNByColumn({ column, data, value, make, model, results }) {
+  let tempResults = data.filter((item) => new RegExp(`.*${value}.*`, 'i').test(item[column]));
+  if (make === 'others' && tempResults.length > 0) {
+    tempResults = filterByOthersMake(tempResults, make);
+  } else if (make !== 'null' && tempResults.length > 0) {
+    tempResults = filterResults(tempResults, make);
+  }
+  if (model !== 'null' && tempResults.length > 0) {
+    tempResults = filterResults(tempResults, model, false);
+  }
+  tempResults.forEach((item) => results.add(item));
+}
+
 export function searchPartNumValue(value, make, model, data = pnData) {
+  // search by part number
   const partNumberBrands = ['Base Part Number', 'Volvo Part Number', 'Mack Part Number'];
   const results = new Set();
   partNumberBrands.forEach((brand) => {
-    let tempResults = data.filter((item) => new RegExp(`.*${value}.*`, 'i').test(item[brand]));
-    if (make === 'others' && tempResults.length > 0) {
-      tempResults = filterByOthersMake(tempResults, make);
-    } else if (make !== 'null' && tempResults.length > 0) {
-      tempResults = filterResults(tempResults, make);
-    }
-    if (model !== 'null' && tempResults.length > 0) {
-      tempResults = filterResults(tempResults, model, false);
-    }
-    tempResults.forEach((item) => results.add(item));
+    filterPNByColumn({ column: brand, data, value, make, model, results });
   });
+  // search by Description aka Part Name
+  if (results.size === 0) {
+    filterPNByColumn({ column: 'Part Name', data, value, make, model, results });
+  }
   return [...results];
 }
 
@@ -207,6 +220,7 @@ function formListener(form) {
 
     if (!crData || !pnData) return;
     ssData.forEach((item) => sessionStorage.removeItem(item));
+    if (sessionStorage.getItem('total-results-amount')) sessionStorage.removeItem('total-results-amount');
     const results = isCrossRefActive
       ? searchCRPartNumValue(value)
       : searchPartNumValue(value, makeFilterValue, modelFilterValue);
@@ -222,7 +236,14 @@ function formListener(form) {
       query.model = modelFilterValue;
     }
     ssDataItems.push(query, results, amountOfProducts);
-    ssData.forEach((item, i) => sessionStorage.setItem(item, JSON.stringify(ssDataItems[i])));
+    ssData.forEach((item, i) => {
+      if (i === 1 && results.length > fitAmount) {
+        fitInStorage = false;
+        return;
+      }
+      sessionStorage.setItem(item, JSON.stringify(ssDataItems[i]));
+    });
+    if (!fitInStorage) sessionStorage.setItem('total-results-amount', results.length);
     url.pathname = '/search/';
     url.search = `?q=${value}&st=${searchType}`;
     window.location.href = url;

--- a/placeholder.json
+++ b/placeholder.json
@@ -29,11 +29,11 @@
     },
     {
       "Key": "Part No",
-      "Text": "Part No"
+      "Text": "Part No or Description"
     },
     {
       "Key": "Part Number Label",
-      "Text": "Part Number OR Description"
+      "Text": "Part Number/Description"
     },
     {
       "Key": "search results title",

--- a/placeholder.json
+++ b/placeholder.json
@@ -1,7 +1,7 @@
 {
-  "total": 20,
+  "total": 21,
   "offset": 0,
-  "limit": 20,
+  "limit": 21,
   "data": [
     {
       "Key": "brand name",
@@ -30,6 +30,10 @@
     {
       "Key": "Part No",
       "Text": "Part No"
+    },
+    {
+      "Key": "Part Number Label",
+      "Text": "Part Number OR Description"
     },
     {
       "Key": "search results title",

--- a/templates/search-results/search-results.js
+++ b/templates/search-results/search-results.js
@@ -16,6 +16,7 @@ const amount = amountOfProducts;
 const urlParams = new URLSearchParams(window.location.search);
 let query = {};
 export const results = [];
+export const allProducts = {};
 let isResultsEmpty = true;
 let isDifferentQuery = false;
 
@@ -103,6 +104,8 @@ export default async function decorate(doc) {
       }
       // when all messages are send, save the data in the window object again if needed
       if (!Object.prototype.hasOwnProperty.call(window, 'allProducts')) {
+        const keys = ['crData', 'pnData', 'imgData'];
+        keys.forEach((key) => { allProducts[key] = data[key]; });
         window.allProducts = data;
       }
       const event = new CustomEvent('DataLoaded', { detail: { results, data } });

--- a/templates/search-results/search-results.js
+++ b/templates/search-results/search-results.js
@@ -1,5 +1,6 @@
 import {
   amountOfProducts,
+  fitAmount,
   searchCRPartNumValue,
   searchPartNumValue,
 } from '../../blocks/search/search.js';
@@ -14,7 +15,7 @@ const contactUsText = getTextLabel('no results contact us');
 const amount = amountOfProducts;
 const urlParams = new URLSearchParams(window.location.search);
 let query = {};
-let results = [];
+export const results = [];
 let isResultsEmpty = true;
 let isDifferentQuery = false;
 
@@ -25,6 +26,7 @@ if (sessionStorage.getItem('query')) {
     sessionStorage.removeItem('results');
     sessionStorage.removeItem('amount');
     sessionStorage.removeItem('query');
+    sessionStorage.removeItem('total-results-amount');
   }
 }
 
@@ -40,7 +42,8 @@ if (!sessionStorage.getItem('query') || isDifferentQuery) {
 }
 
 if (sessionStorage.getItem('results')) {
-  results = JSON.parse(sessionStorage.getItem('results'));
+  results.length = 0;
+  results.push(...JSON.parse(sessionStorage.getItem('results')));
   isResultsEmpty = false;
 }
 
@@ -89,20 +92,21 @@ export default async function decorate(doc) {
 
   productsWorker.onmessage = ({ data }) => {
     if (data.crData && data.pnData && data.imgData) {
-      if (isResultsEmpty) {
+      if (isResultsEmpty || results.length >= fitAmount) {
+        results.length = 0;
         if (searchType === 'cross') {
-          results = searchCRPartNumValue(value, data.crData);
+          results.push(...searchCRPartNumValue(value, data.crData));
         } else {
           const { make, model } = query;
-          results = searchPartNumValue(value, make, model, data.pnData);
+          results.push(...searchPartNumValue(value, make, model, data.pnData));
         }
       }
-      const event = new CustomEvent('DataLoaded', { detail: { results, data } });
-      document.dispatchEvent(event);
       // when all messages are send, save the data in the window object again if needed
       if (!Object.prototype.hasOwnProperty.call(window, 'allProducts')) {
         window.allProducts = data;
       }
+      const event = new CustomEvent('DataLoaded', { detail: { results, data } });
+      document.dispatchEvent(event);
     }
   };
 
@@ -115,6 +119,18 @@ export default async function decorate(doc) {
         searchResultsSection.classList.add('no-results');
         searchResultsSection.insertBefore(fragment, filters);
       }
+    }
+    const equalResults = results.length === detail.results.length;
+    let total = sessionStorage.getItem('total-results-amount');
+    let storageResults = sessionStorage.getItem('results');
+    if (equalResults && !total && results.length >= fitAmount) {
+      sessionStorage.setItem('total-results-amount', results.length);
+      total = results.length.toString();
+    }
+    if (equalResults && !storageResults) {
+      const resultsToSave = results.length >= fitAmount ? results.slice(0, fitAmount) : results;
+      sessionStorage.setItem('results', JSON.stringify(resultsToSave));
+      storageResults = JSON.stringify(resultsToSave);
     }
   });
 

--- a/templates/search-results/search-results.js
+++ b/templates/search-results/search-results.js
@@ -106,13 +106,11 @@ export default async function decorate(doc) {
         window.allProducts = data;
       }
       const event = new CustomEvent('DataLoaded', { detail: { results, data } });
-      console.log('%cDataLoaded event dispatched', 'color: gold');
       document.dispatchEvent(event);
     }
   };
 
   document.addEventListener('DataLoaded', ({ detail }) => {
-    console.log('%cDataLoaded search-results listener', 'color: coral');
     if (detail.results.length === 0) {
       isResultsEmpty = true;
       title.textContent = noResultsContent.replace('[$]', value);

--- a/templates/search-results/search-results.js
+++ b/templates/search-results/search-results.js
@@ -106,11 +106,13 @@ export default async function decorate(doc) {
         window.allProducts = data;
       }
       const event = new CustomEvent('DataLoaded', { detail: { results, data } });
+      console.log('%cDataLoaded event dispatched', 'color: gold');
       document.dispatchEvent(event);
     }
   };
 
   document.addEventListener('DataLoaded', ({ detail }) => {
+    console.log('%cDataLoaded search-results listener', 'color: coral');
     if (detail.results.length === 0) {
       isResultsEmpty = true;
       title.textContent = noResultsContent.replace('[$]', value);


### PR DESCRIPTION
# __Main Fix__
In the Part Number search, the search by Part Name column aka by Description has been added, so, if the search by Part Number doesn't bring any results, then search by "Description". 

The cross-reference search only searches by a partial or full Part number in any of the 4 part number types, not by description.

Even if is the 1st time or the data is removed from the browser's session storage, the search-results template searches again the results to show. If the page is reloaded it shows the total results amount. The storage only saves a maximum of 5,000 results to avoid the error related to the browser storage

Also, if you try a blank search for any of the 2 search types, now shows a no-results message

## loading bug
now if it is the 1st time it does a search, e.g. "wb" as part number search, now the loading message swap with the content and, if the user reloads the page now show placeholders until the data is there after 5 seconds

## __Other Fixes__
Also, fixes the carousel text width on the mobile viewport. Now only modifies the width from 1200px and beyond

Fix #181 

Test URLs:
- Before: https://main--vg-roadchoice-com--hlxsites.hlx.page/
- After: https://181-cr-description-search--vg-roadchoice-com--hlxsites.hlx.page/
