### PR TITLE
181-Fix the amount of items if multiple categories

### DIFF
--- a/blocks/filters/filters.js
+++ b/blocks/filters/filters.js
@@ -4,7 +4,7 @@ let products;
 const titleContent = getTextLabel('Categories');
 const isSearchResult = document.querySelector('.search-results') !== null;
 const urlCategory = new URLSearchParams(window.location.search).get('cat');
-const total = +sessionStorage.getItem('total-results-amount') || 0;
+const total = +sessionStorage.getItem('total-results-amount') || null;
 
 if (isSearchResult) products = JSON.parse(sessionStorage.getItem('results')) || [];
 
@@ -49,7 +49,7 @@ const buildFilter = (cats) => {
     const link = createElement('a', {
       classes: 'categories-link',
       props: { href: filterUrl },
-      textContent: `${category.toLowerCase()} (${total >= amount ? total : amount})`,
+      textContent: `${category.toLowerCase()} (${amount})`,
     });
     item.appendChild(link);
     list.appendChild(item);
@@ -78,5 +78,5 @@ export default async function decorate(block) {
     if (products.length > 0) decorateFilter(block);
   });
 
-  if (products.length > 0) decorateFilter(block);
+  if (products.length > 0 && !total) decorateFilter(block);
 }

--- a/blocks/results-list/results-list.js
+++ b/blocks/results-list/results-list.js
@@ -3,6 +3,7 @@ import productCard from './product-card.js';
 import { amountOfProducts } from '../search/search.js';
 import { results, allProducts } from '../../templates/search-results/search-results.js';
 
+let total = 0;
 let amount = amountOfProducts;
 let products;
 let query;
@@ -11,6 +12,7 @@ let isRendered = false;
 const isSearchResult = document.querySelector('.search-results') !== null;
 
 if (isSearchResult) {
+  total = +sessionStorage.getItem('total-results-amount') || 0;
   amount = JSON.parse(sessionStorage.getItem('amount')) || amountOfProducts;
   products = JSON.parse(sessionStorage.getItem('results')) || [];
   query = JSON.parse(sessionStorage.getItem('query')) || {};
@@ -26,6 +28,9 @@ const searchType = (query.searchType === 'cross' && 'cross') || 'parts';
 const renderResults = ({ loadingElement, productList, isTruckLibrary, detail }) => {
   loadingElement.remove();
   products = category ? products : detail?.results;
+  products = total > 0 && category
+    ? detail?.results.filter((item) => item['Part Category'].toLowerCase() === category)
+    : products;
 
   if (products.length === 0) return;
   products.forEach((prod, idx) => {


### PR DESCRIPTION
## Fixes
### __1.__ This page shows 6 results and then refreshes automatically and then shows 3 results this flicker is not expected :
test path: _search/?q=&st=parts&make=autocar&model=null&cat=shock+absorbers_
- __FIX__: _the results are waiting until the data is downloaded, there's no 6 results anymore_

### __2.__ When clicked on category link the records shown are more than expected :
test path: _search/?q=&st=parts&make=ford&model=null_
- __FIX__: _now the amount is correct_

### __3.__ Navigate to the test path:  _search/?q=&st=parts&make=freightliner&model=null_, then Click on any category it shows incorrect count, then now click browser back button and it shows all incorrect counts
- __FIX__: _that even happens when the page was reloaded, now get the correct amount every filter category_


#

Fix #181

Test URLs:
- Before: https://main--vg-roadchoice-com--hlxsites.hlx.page/
- After: https://181-url-search-issues-going-back--vg-roadchoice-com--hlxsites.hlx.page/
