### PR TITLE
207 search breadcrumb item is not a link

### DIFF
--- a/templates/search-results/search-results.js
+++ b/templates/search-results/search-results.js
@@ -148,7 +148,22 @@ export default async function decorate(doc) {
   section.appendChild(searchResultsWrapper);
 
   main.textContent = '';
-  if (breadcrumb) main.prepend(breadcrumb);
+  if (breadcrumb) {
+    const breadcrumbBlock = breadcrumb.querySelector('.breadcrumb');
+
+    // update breadcrumb to remove the href to the search item
+    const observer = new MutationObserver((mutations) => {
+      const { target } = mutations[0];
+      if (target.dataset.blockStatus === 'loaded') {
+        const breadcrumbList = target.querySelector('.breadcrumb-list');
+        const lastElLink = breadcrumbList.lastElementChild.firstElementChild;
+        lastElLink.removeAttribute('href');
+        observer.disconnect();
+      }
+    });
+    observer.observe(breadcrumbBlock, { attributes: true, attributeFilter: ['data-block-status'] });
+    main.prepend(breadcrumb);
+  }
   if (searchBar) main.prepend(searchBar);
   if (noResults) {
     const fragment = document.createRange().createContextualFragment(noResultsTemplate);


### PR DESCRIPTION
# Fix

To reach the search results page is needed to go through the search form input, so to avoid going by the breadcrumb to an empty page with a bad search, I removed the href attribute from the search breadcrumb item

## Info

Fix  207-2 item

Test URLs:
- Before: https://main--vg-roadchoice-com--hlxsites.hlx.page/
- After: https://207-search-breadcrumb--vg-roadchoice-com--hlxsites.hlx.page/
